### PR TITLE
Validate ThreadContext.num_workers

### DIFF
--- a/pasha/context.py
+++ b/pasha/context.py
@@ -159,9 +159,9 @@ class PoolContext(MapContext):
     """
 
     def __init__(self, num_workers=None):
-        from os import cpu_count
 
-        if num_workers is None:
+        if not num_workers:
+            from os import cpu_count
             num_workers = min(cpu_count() // 2, 10)
 
         super().__init__(num_workers=num_workers)

--- a/pasha/tests/test_context.py
+++ b/pasha/tests/test_context.py
@@ -10,7 +10,7 @@ import pytest
 
 import numpy as np
 import pasha as psh
-from pasha.context import MapContext
+from pasha.context import MapContext, ThreadContext
 from pasha.functor import Functor
 
 
@@ -123,3 +123,12 @@ def test_set_default_context_string(ctx_str, expected_type):
 
     psh.set_default_context(ctx_str)
     assert isinstance(psh.get_default_context(), expected_type)
+
+
+@pytest.mark.parametrize(
+    ['num_workers', 'expected'], [(None, 1), (0, 1), (4, 4)])
+def test_array(num_workers, expected):
+    """Test ThreadContext validation."""
+
+    ctx = ThreadContext(num_workers=num_workers)
+    assert ctx.num_workers >= expected


### PR DESCRIPTION
Hi @philsmt,  

Here is a possible improvement validating the given `ThreadContext.num_workers` at initialization.  

Messing around with [AGIPD notebooks](https://git.xfel.eu/detectors/pycalibration/-/blob/master/notebooks/AGIPD/Characterize_AGIPD_Gain_Darks_NBC.ipynb#L382), I noticed that the notebook may assign 0 threads if there's more files than cores availables.  

It's most likely a non-issue but ~~it's a slow shift~~ it's a simple validation to add here.  

I've tested the changes as seen in the test file.  

Thanks!  
Cyril